### PR TITLE
Fix bug deleting item in input slot if empty slot is shift-clicked

### DIFF
--- a/src/main/java/com/tynoxs/buildersdelight/content/gui/menus/ContainerChisel.java
+++ b/src/main/java/com/tynoxs/buildersdelight/content/gui/menus/ContainerChisel.java
@@ -77,7 +77,7 @@ public class ContainerChisel extends AbstractContainerMenu {
                     }
                     @Override
                     public boolean mayPickup(Player pPlayer) {
-                        if(!ContainerChisel.this.resultSlot.hasItem()){
+                        if(!ContainerChisel.this.resultSlot.hasItem() && this.hasItem()){
                             ContainerChisel.this.craftVariant(this.getItem());
 
                             //play sound after chiseling


### PR DESCRIPTION
Previously, if you placed an item in the input slot and shift clicked an empty variant slot (which might happen accidentally) the input item would be deleted. This simple change fixes this by checking if the clicked slot is empty. :)